### PR TITLE
Remove excessive -x bash debugging flag

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # No set -e here because we want to get a non-zero exit code from terraform_plan.sh
-set -ex
+set -e
 
 echo "Running Terraform Plugin deployment script..."
 


### PR DESCRIPTION
The bash `-x` is too verbose for using in production environment and while reading the GHA logs. Removing.